### PR TITLE
fix docker file with latest nextjs update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,6 @@ USER nextjs
 EXPOSE 3000
 
 ENV PORT 3000
-ENV HOSTNAME localhost
+ENV HOSTNAME "0.0.0.0"
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
Issue: The Dockerfile was deployed successfully, but the port could not be opened with the hostname "localhost".
Issue URL : [Issue 10](https://github.com/zeon-studio/nextplate/issues/10)